### PR TITLE
Added code to clean .lock file of MongoDB

### DIFF
--- a/startfiles/start-mongodb.bat
+++ b/startfiles/start-mongodb.bat
@@ -27,6 +27,12 @@ IF NOT EXIST "%cd%\logs\mongodb.log" (
     echo. 2>"%cd%\logs\mongodb.log"
 )
 
+IF EXIST "%cd%\data\mongod.lock" (
+    echo.
+    echo Deleting previous .lock file leved from last unclean MongoDB shutdown...
+    del 2>"%cd%\data\mongod.lock"
+)
+
 echo.
 echo Starting MongoDB
      %cd%\bin\mongodb\bin\mongod.exe --config "%cd%\bin\mongodb\mongodb.conf" --logpath "%cd%\logs\mongodb.log" --dbpath "%cd%\bin\mongodb\data\db"


### PR DESCRIPTION
Many time it happens that Mongo is shut down in a bad way by Windows Shutdown or for any other reason. This cause the next start of MongoDB to fail and each time i have to go in that folder to delete that lock file.

This additive code check if that .lock file is present and delete it before starting Mongo.

Also, actually the stop script is terminating mongo just in that bad way that leave the lock file there. Actually this is a workaround for that bug.